### PR TITLE
fix: use cmd.exe for `task` execution

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,9 +68,12 @@ jobs:
           echo '{}' > ./package.json
           npm install '@go-task/cli@${{ env.go-task-version }}'
 
-          readonly bin_dir='node_modules/.bin'
-          if [[ -f "./${bin_dir}/task.exe" ]]; then
-            realpath "./${bin_dir}" >> "${GITHUB_PATH}"
+          readonly local_bin_dir='node_modules/.bin'
+          echo '[command]which task'
+          if which task; then
+            :
+          elif [[ -f "./${local_bin_dir}/task.exe" ]]; then
+            realpath "./${local_bin_dir}" >> "${GITHUB_PATH}"
           fi
 
       - name: Run task command

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,12 +73,15 @@ jobs:
           if which task; then
             :
           elif [[ -f "./${local_bin_dir}/task.exe" ]]; then
-            echo "task.exe was installed in ./${local_bin_dir}"
-            realpath "./${local_bin_dir}" >> "${GITHUB_PATH}"
+            local_bin_dir_fullpath="$(cygpath --windows "$(realpath "./${local_bin_dir}")")"
+            readonly local_bin_dir_fullpath
+            echo "task.exe was installed in ${local_bin_dir_fullpath}"
+            realpath "${local_bin_dir_fullpath}" >> "${GITHUB_PATH}"
           else
             find "$(npm bin)" "$(npx node -p 'process.env.npm_config_prefix')" -type f -name 'task.exe' -print0 | while read -r -d '' task_filepath; do
-              echo "task.exe was installed in $(dirname "${task_filepath}")"
-              dirname "${task_filepath}" >> "${GITHUB_PATH}"
+              task_dirpath="$(cygpath --windows "$(dirname "${task_filepath}")")"
+              echo "task.exe was installed in ${task_dirpath}"
+              echo "${task_dirpath}" >> "${GITHUB_PATH}"
             done
           fi
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,6 +68,9 @@ jobs:
           echo '{}' > ./package.json
           npm install '@go-task/cli@${{ env.go-task-version }}'
 
+          echo '[command]which task'
+          which task
+
           readonly bin_dir='node_modules/.bin'
           if [[ -f "./${bin_dir}/task.exe" ]]; then
             realpath "./${bin_dir}" >> "${GITHUB_PATH}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,9 +68,6 @@ jobs:
           echo '{}' > ./package.json
           npm install '@go-task/cli@${{ env.go-task-version }}'
 
-          echo '[command]which task'
-          which task
-
           readonly bin_dir='node_modules/.bin'
           if [[ -f "./${bin_dir}/task.exe" ]]; then
             realpath "./${bin_dir}" >> "${GITHUB_PATH}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,15 +73,12 @@ jobs:
           if which task; then
             :
           elif [[ -f "./${local_bin_dir}/task.exe" ]]; then
-            local_bin_dir_fullpath="$(cygpath --windows "$(realpath "./${local_bin_dir}")")"
-            readonly local_bin_dir_fullpath
-            echo "task.exe was installed in ${local_bin_dir_fullpath}"
-            realpath "${local_bin_dir_fullpath}" >> "${GITHUB_PATH}"
+            echo "task.exe was installed in ./${local_bin_dir}"
+            realpath "./${local_bin_dir}" >> "${GITHUB_PATH}"
           else
             find "$(npm bin)" "$(npx node -p 'process.env.npm_config_prefix')" -type f -name 'task.exe' -print0 | while read -r -d '' task_filepath; do
-              task_dirpath="$(cygpath --windows "$(dirname "${task_filepath}")")"
-              echo "task.exe was installed in ${task_dirpath}"
-              echo "${task_dirpath}" >> "${GITHUB_PATH}"
+              echo "task.exe was installed in $(dirname "${task_filepath}")"
+              dirname "${task_filepath}" >> "${GITHUB_PATH}"
             done
           fi
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,19 +85,25 @@ jobs:
             done
           fi
 
+      - name: Show the path where the task command is installed
+        shell: pwsh
+        # see https://qiita.com/Hiraku/items/e42bc5756157949a9742
+        run: (Get-Command task).Definition
+
       - name: Run task command
         shell: cmd
-        run: |
-          echo "[command]where task"
-          where task
-          echo "[command]task --version"
-          task --version
+        run: task --version
 
   install-using-chocolatey:
     runs-on: windows-latest
     steps:
       - name: Install go-task
         run: choco install go-task --version ${{ env.go-task-version }} --allow-multiple-versions --yes
+
+      - name: Show the path where the task command is installed
+        shell: pwsh
+        # see https://qiita.com/Hiraku/items/e42bc5756157949a9742
+        run: (Get-Command task).Definition
 
       - name: Run task command
         shell: cmd
@@ -114,6 +120,11 @@ jobs:
           find ./task -type f -name 'task.exe' -print0 | while read -r -d '' task_filepath; do
             dirname "${task_filepath}" >> "${GITHUB_PATH}"
           done
+
+      - name: Show the path where the task command is installed
+        shell: pwsh
+        # see https://qiita.com/Hiraku/items/e42bc5756157949a9742
+        run: (Get-Command task).Definition
 
       - name: Run task command
         shell: cmd

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,11 @@ jobs:
 
       - name: Run task command
         shell: cmd
-        run: task --version
+        run: |
+          echo "[command]where task"
+          where task
+          echo "[command]task --version"
+          task --version
 
   install-using-chocolatey:
     runs-on: windows-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,14 +68,14 @@ jobs:
           echo '{}' > ./package.json
           npm install '@go-task/cli@${{ env.go-task-version }}'
 
-      - name: Run task command
-        shell: bash
-        run: |
-          if [[ -f ./node_modules/.bin/task.exe ]]; then
-            ./node_modules/.bin/task.exe --version
-          else
-            task --versiond
+          readonly bin_dir='node_modules/.bin'
+          if [[ -f "./${bin_dir}/task.exe" ]]; then
+            realpath "./${bin_dir}" >> "${GITHUB_PATH}"
           fi
+
+      - name: Run task command
+        shell: cmd
+        run: task --version
 
   install-using-chocolatey:
     runs-on: windows-latest
@@ -84,6 +84,7 @@ jobs:
         run: choco install go-task --version ${{ env.go-task-version }} --allow-multiple-versions --yes
 
       - name: Run task command
+        shell: cmd
         run: task --version
 
   install-from-github-release:
@@ -99,4 +100,5 @@ jobs:
           done
 
       - name: Run task command
+        shell: cmd
         run: task --version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,7 +73,13 @@ jobs:
           if which task; then
             :
           elif [[ -f "./${local_bin_dir}/task.exe" ]]; then
+            echo "task.exe was installed in ./${local_bin_dir}"
             realpath "./${local_bin_dir}" >> "${GITHUB_PATH}"
+          else
+            find "$(npm bin)" "$(npx node -p 'process.env.npm_config_prefix')" -type f -name 'task.exe' -print0 | while read -r -d '' task_filepath; do
+              echo "task.exe was installed in $(dirname "${task_filepath}")"
+              dirname "${task_filepath}" >> "${GITHUB_PATH}"
+            done
           fi
 
       - name: Run task command


### PR DESCRIPTION
If an incorrect .exe file is executed in Windows Bash, the following error is thrown:

    .../task: cannot execute binary file: Exec format error

This is not the expected error message. So instead of Bash, use cmd.exe.