### PR TITLE
test: exclude go-task installations with Chocolatey from testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,8 +6,7 @@ on:
       - "**"
   pull_request:
 env:
-  # Note: The latest version is 3.25.0, but this version has not yet been released to Chocolatey.
-  go-task-version: 3.24.0
+  go-task-version: 3.25.0
 jobs:
   find-available-node-versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -101,27 +101,6 @@ jobs:
         shell: cmd
         run: task --version
 
-  install-using-chocolatey:
-    runs-on: windows-latest
-    steps:
-      - name: Install go-task
-        run: choco install go-task --version ${{ env.go-task-version }} --allow-multiple-versions --yes
-
-      - name: Show the path where the task command is installed
-        shell: pwsh
-        # see https://qiita.com/Hiraku/items/e42bc5756157949a9742
-        run: (Get-Command task).Definition
-
-      - name: Show the file hash of the installed task command
-        shell: pwsh
-        # see https://qiita.com/Hiraku/items/e42bc5756157949a9742
-        # see https://www.sukerou.com/2021/08/powershell.html
-        run: (Get-FileHash -Algorithm SHA512 -LiteralPath (Get-Command task).Definition).Hash
-
-      - name: Run task command
-        shell: cmd
-        run: task --version
-
   install-from-github-release:
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
The `task.exe` installed by Chocolatey is a different binary than the asset released on GitHub.
It works correctly, but is not usable for comparison, so it is excluded from the test.